### PR TITLE
Version 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin-component-factory/vcf-multiselect-combo-box",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A multiselect combobox",
   "main": "src/vcf-multiselect-combo-box.js",
   "author": "Vaadin Ltd",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -150,7 +150,7 @@ export function _filteredItemsChanged(e, itemValuePath, itemLabelPath) {
   }
   if (e.path === 'filteredItems' || e.path === 'filteredItems.splices') {
     this._setOverlayItems(this.filteredItems);
-    if (this.opened || this.autoOpenDisabled) {
+    if ((this.opened || this.autoOpenDisabled) && this.selectedItems.length !== this.filteredItems.length) {
       this._focusedIndex = this.filteredItems.findIndex(item => !this._isItemChecked(item));
     } else {
       this._focusedIndex = -1;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -151,10 +151,7 @@ export function _filteredItemsChanged(e, itemValuePath, itemLabelPath) {
   if (e.path === 'filteredItems' || e.path === 'filteredItems.splices') {
     this._setOverlayItems(this.filteredItems);
     if (this.opened || this.autoOpenDisabled) {
-      const focusedIndex = this.filteredItems.findIndex(item => !this._isItemChecked(item));
-      if (focusedIndex > 0) {
-        this._focusedIndex = focusedIndex;
-      }
+      this._focusedIndex = this.filteredItems.findIndex(item => !this._isItemChecked(item));
     } else {
       this._focusedIndex = -1;
     }

--- a/src/vcf-multiselect-combo-box.js
+++ b/src/vcf-multiselect-combo-box.js
@@ -278,7 +278,7 @@ class VcfMultiselectComboBox extends ElementMixin(ThemableMixin(ComboBoxElement)
   }
 
   static get version() {
-    return '0.5.0';
+    return '0.5.1';
   }
 }
 


### PR DESCRIPTION
Includes:
1 - fix to bring back focus of the first item on filtering (stopped working on version 0.4.0)
2 - fix to avoid loop on scrolling when combobox has a large number of items (previous fix caused issue 1)